### PR TITLE
fix: initialization issues with undoable commands

### DIFF
--- a/lib/flutter_command.dart
+++ b/lib/flutter_command.dart
@@ -658,7 +658,7 @@ abstract class Command<TParam, TResult> extends CustomValueNotifier<TResult> {
       catchAlways,
       notifyOnlyWhenValueChanges,
       debugName,
-      true,
+      false,
     );
   }
 
@@ -766,11 +766,11 @@ abstract class Command<TParam, TResult> extends CustomValueNotifier<TResult> {
           : null,
       undoOnExecutionFailure,
       false,
-      true,
+      false,
       catchAlways,
       notifyOnlyWhenValueChanges,
       debugName,
-      true,
+      false,
     );
   }
 


### PR DESCRIPTION
Fixed issues in `Command.createUndoableNoResult` and `Command.createUndoable` where the values for `noParamValue` and `noReturnValue` were set to `true` where they had to be `false`.